### PR TITLE
do not force expiry for ACK

### DIFF
--- a/README
+++ b/README
@@ -109,8 +109,9 @@ probably only makes sense to use this together with
 "hide_ack_from_broken" set to "false".
 
 "default_ack_duration" and "default_downtime_duration" set the
-corresponding default expiry times. If unset, both of them default to
-"1d".
+corresponding default expiry times. If unset, "default_ack_duration"
+defaults to the string "none" (no expiry) and
+"default_downtime_duration" defaults to "1d".
 
 "show_detailed_output_on_startup" is optional. If set to "false",
 detailed check output will not be shown and you must press the

--- a/icinga.py
+++ b/icinga.py
@@ -182,10 +182,10 @@ class Icinga(object):
             for i in items[c:c + chunk_size]:
                 filters.append('(' + i.get_filter() + ')')
 
+
             data = {
                 'author': getuser(),
                 'comment': comment,
-                'expiry': end_time,
                 'type': item_type,
                 'filter': ' || '.join(filters),
 
@@ -193,6 +193,8 @@ class Icinga(object):
                 # service or host fully recovers. Defaults to false."
                 'sticky': True,
             }
+            if end_time:
+                data['end_time'] = end_time
 
             r = post(
                 self._api('actions/acknowledge-problem'),

--- a/icinga.py
+++ b/icinga.py
@@ -194,7 +194,7 @@ class Icinga(object):
                 'sticky': True,
             }
             if end_time:
-                data['end_time'] = end_time
+                data['expiry'] = end_time
 
             r = post(
                 self._api('actions/acknowledge-problem'),

--- a/terminga
+++ b/terminga
@@ -255,7 +255,18 @@ def duration_to_times(duration):
     return start_time, end_time
 
 
-def query_duration_comment(win, items, external_tool, default_duration):
+def query_duration_comment(
+    win,
+    items,
+    external_tool,
+    default_duration,
+    needs_duration,
+):
+    if needs_duration:
+        msg_suffix = ''
+    else:
+        msg_suffix = ' or "none"'
+
     comment = None
 
     duration = query_string(win, f'Duration [{default_duration}]: ')
@@ -267,11 +278,16 @@ def query_duration_comment(win, items, external_tool, default_duration):
 
     times = duration_to_times(duration)
     if times is DurationResult.ParseError:
-        status(win, 'Invalid duration! Use something like 30s, 5m, 1h, 2d or "none"')
+        status(win, f'Invalid duration! Use something like 30s, 5m, 1h, 2d{msg_suffix}')
         win.refresh()
         sleep(2)
         return None
     elif times is DurationResult.NoDuration:
+        if needs_duration:
+            status(win, 'You need to specify a duration, aborted!')
+            win.refresh()
+            sleep(2)
+            return None
         start_time, end_time = None, None
     else:
         start_time, end_time = times
@@ -727,6 +743,7 @@ def interact(win, icinga, config):
                 items_for_action,
                 config['external_tool'],
                 icinga.settings['default_ack_duration'],
+                False,
             )
             if response is not None:
                 comment, _, end_time = response
@@ -743,6 +760,7 @@ def interact(win, icinga, config):
                 items_for_action,
                 config['external_tool'],
                 icinga.settings['default_downtime_duration'],
+                True,
             )
             if response is not None:
                 comment, start_time, end_time = response

--- a/terminga
+++ b/terminga
@@ -247,22 +247,30 @@ def duration_to_times(duration):
     return start_time, end_time
 
 
-def query_duration_comment(win, items, external_tool, default_duration):
+def query_duration_comment(win, items, external_tool, default_duration, force_duration=True):
     comment = None
 
-    duration = query_string(win, f'Duration [{default_duration}]: ')
+    if force_duration:
+        duration = query_string(win, f'Duration [{default_duration}]: ')
+    else:
+        duration = query_string(win, 'Duration: ')
     if ' ' in duration:
         duration, comment = duration.split(' ', maxsplit=1)
 
-    if duration == '':
+    if duration == '' and force_duration:
         duration = default_duration
 
     times = duration_to_times(duration)
     if times is None:
-        status(win, 'Invalid duration! Use something like 30s, 5m, 1h, 2d, ...')
-        win.refresh()
-        sleep(2)
-        return None
+        if force_duration:
+            status(win, 'Invalid duration! Use something like 30s, 5m, 1h, 2d, ...')
+            win.refresh()
+            sleep(2)
+            return None
+        else:
+            start_time, end_time = None, None
+    else:
+        start_time, end_time = times
 
     if comment is None:
         comment = query_string(win, 'Comment: ')
@@ -275,8 +283,6 @@ def query_duration_comment(win, items, external_tool, default_duration):
 
     if comment == '!':
         comment = external_tool_output(items, external_tool)
-
-    start_time, end_time = times
 
     return comment, start_time, end_time
 
@@ -717,6 +723,7 @@ def interact(win, icinga, config):
                 items_for_action,
                 config['external_tool'],
                 icinga.settings['default_ack_duration'],
+                force_duration=False,
             )
             if response is not None:
                 comment, _, end_time = response

--- a/terminga
+++ b/terminga
@@ -258,29 +258,19 @@ def duration_to_times(duration):
 def query_duration_comment(win, items, external_tool, default_duration):
     comment = None
 
-    force_duration = True
-    if default_duration.lower() == 'none':
-        force_duration = False
-
-    if force_duration:
-        duration = query_string(win, f'Duration [{default_duration}]: ')
-    else:
-        duration = query_string(win, 'Duration: ')
+    duration = query_string(win, f'Duration [{default_duration}]: ')
     if ' ' in duration:
         duration, comment = duration.split(' ', maxsplit=1)
 
-    if duration == '' and force_duration:
+    if duration == '':
         duration = default_duration
 
     times = duration_to_times(duration)
     if times is DurationResult.ParseError:
-        if force_duration:
-            status(win, 'Invalid duration! Use something like 30s, 5m, 1h, 2d, ...')
-            win.refresh()
-            sleep(2)
-            return None
-        else:
-            start_time, end_time = None, None
+        status(win, 'Invalid duration! Use something like 30s, 5m, 1h, 2d or "none"')
+        win.refresh()
+        sleep(2)
+        return None
     elif times is DurationResult.NoDuration:
         start_time, end_time = None, None
     else:

--- a/terminga
+++ b/terminga
@@ -6,6 +6,7 @@ import re
 
 from curses.textpad import Textbox
 from datetime import datetime, timedelta
+from enum import Enum, auto
 from json import loads
 from operator import itemgetter
 from os import execv, fdopen, remove, close
@@ -44,6 +45,10 @@ STATES = {
     'critical': 2,
     'unknown': 3,
 }
+
+class DurationResult(Enum):
+    NoDuration = auto()
+    ParseError = auto()
 
 
 def addstr(win, *args, **kwargs):
@@ -228,7 +233,7 @@ def list_items(
 
 def duration_to_times(duration):
     if duration.lower() == 'none':
-        return False
+        return DurationResult.NoDuration
 
     try:
         if duration.endswith('s'):
@@ -240,9 +245,9 @@ def duration_to_times(duration):
         elif duration.endswith('d'):
             seconds = int(duration[:-1]) * 60 * 60 * 24
         else:
-            return None
+            return DurationResult.ParseError
     except:
-        return None
+        return DurationResult.ParseError
 
     start_time = datetime.now().timestamp()
     end_time = start_time + seconds
@@ -268,7 +273,7 @@ def query_duration_comment(win, items, external_tool, default_duration):
         duration = default_duration
 
     times = duration_to_times(duration)
-    if times is None:
+    if times is DurationResult.ParseError:
         if force_duration:
             status(win, 'Invalid duration! Use something like 30s, 5m, 1h, 2d, ...')
             win.refresh()
@@ -276,7 +281,7 @@ def query_duration_comment(win, items, external_tool, default_duration):
             return None
         else:
             start_time, end_time = None, None
-    elif times is False:
+    elif times is DurationResult.NoDuration:
         start_time, end_time = None, None
     else:
         start_time, end_time = times

--- a/terminga
+++ b/terminga
@@ -227,6 +227,9 @@ def list_items(
 
 
 def duration_to_times(duration):
+    if duration.lower() == 'none':
+        return False
+
     try:
         if duration.endswith('s'):
             seconds = int(duration[:-1])
@@ -247,8 +250,12 @@ def duration_to_times(duration):
     return start_time, end_time
 
 
-def query_duration_comment(win, items, external_tool, default_duration, force_duration=True):
+def query_duration_comment(win, items, external_tool, default_duration):
     comment = None
+
+    force_duration = True
+    if default_duration.lower() == 'none':
+        force_duration = False
 
     if force_duration:
         duration = query_string(win, f'Duration [{default_duration}]: ')
@@ -269,6 +276,8 @@ def query_duration_comment(win, items, external_tool, default_duration, force_du
             return None
         else:
             start_time, end_time = None, None
+    elif times is False:
+        start_time, end_time = None, None
     else:
         start_time, end_time = times
 
@@ -723,7 +732,6 @@ def interact(win, icinga, config):
                 items_for_action,
                 config['external_tool'],
                 icinga.settings['default_ack_duration'],
-                force_duration=False,
             )
             if response is not None:
                 comment, _, end_time = response
@@ -852,7 +860,7 @@ if __name__ == '__main__':
     icinga.settings = {
         'auth': get_auth_from_config(config),
         'base_url': config['icinga_url'],
-        'default_ack_duration': config.get('default_ack_duration', '1d'),
+        'default_ack_duration': config.get('default_ack_duration', 'none'),
         'default_downtime_duration': config.get('default_downtime_duration', '1d'),
         'use_group_filters': True,
         'group_filters': config.get('group_filters', {}),


### PR DESCRIPTION
Having an expiry time is fine for some services, but not for others. The existing implementation did make it impossible to add a non-expiring ACK to a host/service.